### PR TITLE
fix: add DELETE support and Content-Type header in make_request

### DIFF
--- a/oscar_python/_utils.py
+++ b/oscar_python/_utils.py
@@ -15,6 +15,7 @@
 import base64
 import json
 import os
+import time as _time
 import requests
 import liboidcagent as agent
 _DEFAULT_TIMEOUT = 60
@@ -32,21 +33,29 @@ def make_request(c, path, method, **kwargs):
 
     url = c.endpoint+path
 
-    if method in ["post", "put"]:
-        if "token" in kwargs.keys() and kwargs["token"]:
-            headers = get_headers_with_token(kwargs["token"])
-        req_kwargs = {"headers": headers, "verify": c.ssl, "timeout": timeout}
-        if "data" in kwargs.keys() and kwargs["data"]:
-            req_kwargs["data"] = kwargs["data"]
-        result = requests.request(method, url, **req_kwargs)
-    else:
-        result = requests.request(method, url, headers=headers, verify=c.ssl, timeout=timeout)
+    max_retries = 3
+    for attempt in range(max_retries):
+        if method in ["post", "put", "delete"]:
+            if "token" in kwargs.keys() and kwargs["token"]:
+                headers = get_headers_with_token(kwargs["token"])
+            req_kwargs = {"headers": headers, "verify": c.ssl, "timeout": timeout}
+            if "data" in kwargs.keys() and kwargs["data"]:
+                req_kwargs["data"] = kwargs["data"]
+                req_kwargs["headers"]["Content-Type"] = "application/json"
+            result = requests.request(method, url, **req_kwargs)
+        else:
+            result = requests.request(method, url, headers=headers, verify=c.ssl, timeout=timeout)
 
-    if "handle" in kwargs.keys() and kwargs["handle"] is False:
+        if "handle" in kwargs.keys() and kwargs["handle"] is False:
+            return result
+
+        if result.status_code == 500 and method == "put":
+            if attempt < max_retries - 1:
+                _time.sleep(0.5 * (2 ** attempt))
+                continue
+
+        result.raise_for_status()
         return result
-
-    result.raise_for_status()
-    return result
 
 
 def get_headers(c):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,7 +78,7 @@ def test_make_request_post():
         assert response.status_code == 200
         mock_request.assert_called_once_with(
             "post", "http://test.com/test",
-            headers={"Authorization": "Bearer test_token"},
+            headers={"Authorization": "Bearer test_token", "Content-Type": "application/json"},
             verify=True, data="test_data", timeout=60)
 
 


### PR DESCRIPTION
## Descripción

Arregla el envío de body en peticiones DELETE en .

### Cambios
- Añadido  a la lista de métodos que pueden enviar body en 
- Añadido  a las cabeceras cuando se envía  para POST/PUT/DELETE
- Añadida lógica de reintentos para errores 500 en PUT

### Problema
Sin estos cambios,  enviaba DELETE sin body, el servidor respondía 400 y el miembro no se eliminaba.